### PR TITLE
Added util to get job names, also ran BLACK and reordered imports

### DIFF
--- a/batch/batch_utils.py
+++ b/batch/batch_utils.py
@@ -5,27 +5,35 @@ Batch docs:  https://hail.is/docs/batch/api/batch/hailtop.batch.job.Job.html#hai
 """
 
 import collections
-import configargparse
 import contextlib
 import itertools
 import logging
 import os
 import subprocess
+from typing import List, Union
+
+import configargparse
 
 import hailtop.batch as hb
+import hailtop.batch_client.client as bc
 from hailtop.batch.job import Job
-from typing import Union
 
 _GCLOUD_PROJECT = None
 
+
 class HG38_REF_PATHS:
-    fasta = "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta"
+    fasta = (
+        "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta"
+    )
     fai = "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai"
     dict = "gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.dict"
     gencode_v36_gtf = "gs://macarthurlab-rnaseq/ref/gencode.v36.annotation.gtf"
 
+
 class HG37_REF_PATHS:
-    fasta = "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta"
+    fasta = (
+        "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta"
+    )
     fai = "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.fasta.fai"
     dict = "gs://gcp-public-data--broad-references/hg19/v0/Homo_sapiens_assembly19.dict"
 
@@ -40,28 +48,73 @@ def init_arg_parser(
     default_temp_bucket="macarthurlab-cromwell",
     default_cpu=1,
     default_memory=3.75,
-    parser=configargparse.ArgumentParser(formatter_class=configargparse.ArgumentDefaultsRawHelpFormatter),
+    parser=configargparse.ArgumentParser(
+        formatter_class=configargparse.ArgumentDefaultsRawHelpFormatter
+    ),
     gsa_key_file=None,
 ):
     """Initializes and returns an argparse instance with common pipeline args pre-defined."""
 
     local_or_cluster_grp = parser.add_mutually_exclusive_group(required=True)
-    local_or_cluster_grp.add_argument("--local", action="store_true", help="Batch: run locally")
-    local_or_cluster_grp.add_argument("--cluster", action="store_true", help="Batch: submit to cluster")
-    parser.add_argument("-r", "--raw", action="store_true", help="Batch: run directly on the machine, without using a docker image")
+    local_or_cluster_grp.add_argument(
+        "--local", action="store_true", help="Batch: run locally"
+    )
+    local_or_cluster_grp.add_argument(
+        "--cluster", action="store_true", help="Batch: submit to cluster"
+    )
+    parser.add_argument(
+        "-r",
+        "--raw",
+        action="store_true",
+        help="Batch: run directly on the machine, without using a docker image",
+    )
 
-    parser.add_argument("--gsa-key-file", default=gsa_key_file, help="Batch: path of gcloud service account .json "
-        "key file. If provided, Batch will mount this file into the docker image so gcloud commands can run as this service account.")
-    parser.add_argument("--batch-billing-project", default=default_billing_project, help="Batch: this billing project will be "
-        "charged when running jobs on the Batch cluster. To set up a billing project name, contact the hail team.")
-    parser.add_argument("--batch-temp-bucket", default=default_temp_bucket, help="Batch: bucket where it stores temp "
+    parser.add_argument(
+        "--gsa-key-file",
+        default=gsa_key_file,
+        help="Batch: path of gcloud service account .json "
+        "key file. If provided, Batch will mount this file into the docker image so gcloud commands can run as this service account.",
+    )
+    parser.add_argument(
+        "--batch-billing-project",
+        default=default_billing_project,
+        help="Batch: this billing project will be "
+        "charged when running jobs on the Batch cluster. To set up a billing project name, contact the hail team.",
+    )
+    parser.add_argument(
+        "--batch-temp-bucket",
+        default=default_temp_bucket,
+        help="Batch: bucket where it stores temp "
         "files. The batch service-account must have Admin permissions for this bucket. These can be added by running "
-        "gsutil iam ch serviceAccount:[SERVICE_ACCOUNT_NAME]:objectAdmin gs://[BUCKET_NAME]")
-    parser.add_argument("-t", "--cpu", type=float, default=default_cpu, choices=[0.25, 0.5, 1, 2, 4, 8, 16], help="Batch: number of CPUs (eg. 0.5)")
-    parser.add_argument("-m", "--memory", type=float, default=default_memory, help="Batch: memory in gigabytes (eg. 3.75)")
-    parser.add_argument("-f", "--force", action="store_true", help="Recompute and overwrite cached or previously computed data")
-    parser.add_argument("--start-with", type=int, help="Start from this step in the pipeline")
-    parser.add_argument("--dry-run", action="store_true", help="Don't run commands, just print them.")
+        "gsutil iam ch serviceAccount:[SERVICE_ACCOUNT_NAME]:objectAdmin gs://[BUCKET_NAME]",
+    )
+    parser.add_argument(
+        "-t",
+        "--cpu",
+        type=float,
+        default=default_cpu,
+        choices=[0.25, 0.5, 1, 2, 4, 8, 16],
+        help="Batch: number of CPUs (eg. 0.5)",
+    )
+    parser.add_argument(
+        "-m",
+        "--memory",
+        type=float,
+        default=default_memory,
+        help="Batch: memory in gigabytes (eg. 3.75)",
+    )
+    parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="Recompute and overwrite cached or previously computed data",
+    )
+    parser.add_argument(
+        "--start-with", type=int, help="Start from this step in the pipeline"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Don't run commands, just print them."
+    )
     parser.add_argument("--verbose", action="store_true", help="Verbose log output.")
     return parser
 
@@ -79,9 +132,15 @@ def run_batch(args, batch_name=None):
     """
 
     if args.local:
-        backend = hb.LocalBackend() if args.raw else hb.LocalBackend(gsa_key_file=args.gsa_key_file)
+        backend = (
+            hb.LocalBackend()
+            if args.raw
+            else hb.LocalBackend(gsa_key_file=args.gsa_key_file)
+        )
     else:
-        backend = hb.ServiceBackend(billing_project=args.batch_billing_project, bucket=args.batch_temp_bucket)
+        backend = hb.ServiceBackend(
+            billing_project=args.batch_billing_project, bucket=args.batch_temp_bucket
+        )
 
     try:
         batch = hb.Batch(backend=backend, name=batch_name)
@@ -99,12 +158,12 @@ def run_batch(args, batch_name=None):
 
 
 def init_job(
-        batch,
-        name: str = None,
-        image: str = None,
-        cpu: float = None,
-        memory: float = None,
-        disk_size: float = None,
+    batch,
+    name: str = None,
+    image: str = None,
+    cpu: float = None,
+    memory: float = None,
+    disk_size: float = None,
 ):
     """Common job init steps
 
@@ -123,23 +182,31 @@ def init_job(
 
     if cpu:
         if cpu < 0.25 or cpu > 16:
-            raise ValueError(f"CPU arg is {cpu}. This is outside the range of 0.25 to 16 CPUs")
+            raise ValueError(
+                f"CPU arg is {cpu}. This is outside the range of 0.25 to 16 CPUs"
+            )
 
         j.cpu(cpu)  # Batch default is 1
 
     if memory:
         if memory < 0.1 or memory > 60:
-            raise ValueError(f"Memory arg is {memory}. This is outside the range of 0.1 to 60 Gb")
+            raise ValueError(
+                f"Memory arg is {memory}. This is outside the range of 0.1 to 60 Gb"
+            )
 
         j.memory(f"{memory}Gi")  # Batch default is 3.75G
 
     if disk_size:
         if disk_size < 1 or disk_size > 1000:
-            raise ValueError(f"Disk size arg is {disk_size}. This is outside the range of 1 to 1000 Gb")
+            raise ValueError(
+                f"Disk size arg is {disk_size}. This is outside the range of 1 to 1000 Gb"
+            )
 
-        j.storage(f'{disk_size}Gi')
+        j.storage(f"{disk_size}Gi")
 
-    j.command("set -euxo pipefail")  # set bash options for easier debugging and to make command execution more robust
+    j.command(
+        "set -euxo pipefail"
+    )  # set bash options for easier debugging and to make command execution more robust
 
     return j
 
@@ -181,25 +248,38 @@ def switch_gcloud_auth_to_user_account(
     """
 
     batch_job.command(f"gcloud auth list")
-    batch_job.command(f"gcloud auth activate-service-account --key-file /gsa-key/key.json")
-    batch_job.command(f"gsutil -m cp -r {os.path.join(gs_path_of_gcloud_credentials, '.config')} /tmp/")
+    batch_job.command(
+        f"gcloud auth activate-service-account --key-file /gsa-key/key.json"
+    )
+    batch_job.command(
+        f"gsutil -m cp -r {os.path.join(gs_path_of_gcloud_credentials, '.config')} /tmp/"
+    )
     batch_job.command(f"rm -rf ~/.config")
     batch_job.command(f"mv /tmp/.config ~/")
     batch_job.command(f"gcloud config set account {gcloud_user_account}")
     if gcloud_project or _GCLOUD_PROJECT:
-        batch_job.command(f"gcloud config set project {gcloud_project or _GCLOUD_PROJECT}")
+        batch_job.command(
+            f"gcloud config set project {gcloud_project or _GCLOUD_PROJECT}"
+        )
 
-    batch_job.command(f"gcloud auth list")  # print auth list again to show that 'gcloud config set account' succeeded.
+    batch_job.command(
+        f"gcloud auth list"
+    )  # print auth list again to show that 'gcloud config set account' succeeded.
 
     # attach credentials to batch_job object
     batch_job._batch_utils_gs_path_of_gcloud_credentials = gs_path_of_gcloud_credentials
     batch_job._batch_utils_gcloud_user_account = gcloud_user_account
 
+
 class StorageBucketRegionException(Exception):
     pass
 
 
-def check_storage_bucket_region(google_storage_paths: Union[str, list], gcloud_project: str = None, verbose: bool = True):
+def check_storage_bucket_region(
+    google_storage_paths: Union[str, list],
+    gcloud_project: str = None,
+    verbose: bool = True,
+):
     """Checks whether the given google storage path(s) are stored in US-CENTRAL1 - the region where the hail Batch
     cluster is located. Localizing data from other regions will be slower and result in egress charges.
 
@@ -217,17 +297,23 @@ def check_storage_bucket_region(google_storage_paths: Union[str, list], gcloud_p
         if gcloud_project or _GCLOUD_PROJECT:
             gsutil_command += f" -u {gcloud_project or _GCLOUD_PROJECT}"
 
-        output = subprocess.check_output(f"{gsutil_command} ls -L -b gs://{bucket}", shell=True, encoding="UTF-8")
+        output = subprocess.check_output(
+            f"{gsutil_command} ls -L -b gs://{bucket}", shell=True, encoding="UTF-8"
+        )
         for line in output.split("\n"):
             if "Location constraint:" in line:
                 location = line.strip().split()[-1]
                 break
         else:
-            raise StorageBucketRegionException(f"ERROR: Couldn't determine gs://{bucket} bucket region.")
+            raise StorageBucketRegionException(
+                f"ERROR: Couldn't determine gs://{bucket} bucket region."
+            )
 
         if location not in {"US", "US-CENTRAL1"}:
-            raise StorageBucketRegionException(f"ERROR: gs://{bucket} is located in {location}. This may cause egress "
-                f"charges when copying files to the Batch cluster which is in US-CENTRAL.")
+            raise StorageBucketRegionException(
+                f"ERROR: gs://{bucket} is located in {location}. This may cause egress "
+                f"charges when copying files to the Batch cluster which is in US-CENTRAL."
+            )
 
         if verbose:
             print(f"Confirmed gs://{bucket} is in {location}")
@@ -238,7 +324,9 @@ def check_storage_bucket_region(google_storage_paths: Union[str, list], gcloud_p
 _GCSFUSE_MOUNTED_BUCKETS_PER_JOB = collections.defaultdict(set)
 
 
-def localize_file(job, google_storage_path: str, gcloud_project: str = None, use_gcsfuse: bool = False) -> str:
+def localize_file(
+    job, google_storage_path: str, gcloud_project: str = None, use_gcsfuse: bool = False
+) -> str:
     """Copies a file from a google bucket to the local filesystem and returns the new absolute local path.
     Requires gsutil to exist inside the docker container.
 
@@ -270,7 +358,9 @@ def localize_file(job, google_storage_path: str, gcloud_project: str = None, use
         root_dir = "/localized"
         local_dir = os.path.join(root_dir, dirname)
         local_file_path = os.path.join(root_dir, path)
-        job.command(f"mkdir -p '{local_dir}'; time {gsutil_command} -m cp -r '{google_storage_path}' '{local_file_path}'")
+        job.command(
+            f"mkdir -p '{local_dir}'; time {gsutil_command} -m cp -r '{google_storage_path}' '{local_file_path}'"
+        )
 
     job.command(f"ls -lh '{local_file_path}'")  # make sure file exists
 
@@ -313,39 +403,60 @@ def localize_via_temp_bucket(
     if gcloud_project or _GCLOUD_PROJECT:
         gsutil_command_prefix += f" -u {gcloud_project or _GCLOUD_PROJECT}"
 
-    batch = job._batch  # the _batch attribute is set within Batch when the Job object is created.
-    batch_id = abs(hash(batch)) % 10**9
-    job_id = abs(hash(job)) % 10**9
+    batch = (
+        job._batch
+    )  # the _batch attribute is set within Batch when the Job object is created.
+    batch_id = abs(hash(batch)) % 10 ** 9
+    job_id = abs(hash(job)) % 10 ** 9
 
     temp_bucket = temp_bucket or getattr(batch, "batch_utils_temp_bucket", None)
     if not temp_bucket:
         raise ValueError("temp bucket not specified.")
 
-    temp_file_path = f"gs://{temp_bucket}/batch_{batch_id}/job_{job_id}/" + google_storage_path.replace("gs://", "")
+    temp_file_path = (
+        f"gs://{temp_bucket}/batch_{batch_id}/job_{job_id}/"
+        + google_storage_path.replace("gs://", "")
+    )
 
     if temp_file_path in _PATHS_LOCALIZED_VIA_TEMP_BUCKET_PER_JOB[job_id]:
-        raise ValueError(f"{google_storage_path} has already been localized via temp bucket.")
+        raise ValueError(
+            f"{google_storage_path} has already been localized via temp bucket."
+        )
     _PATHS_LOCALIZED_VIA_TEMP_BUCKET_PER_JOB[job_id].add(temp_file_path)
 
-    job.command(f"{gsutil_command_prefix} -m cp -r {google_storage_path} {temp_file_path}")
+    job.command(
+        f"{gsutil_command_prefix} -m cp -r {google_storage_path} {temp_file_path}"
+    )
 
     # temp file cleanup job
-    cleanup_job_name = (f"{job.name} " if job.name else "") + f"cleanup {os.path.basename(temp_file_path)}"
-    cleanup_job = init_job(batch, cleanup_job_name, job._image, cpu=0.25, memory=0.25*3.75)
+    cleanup_job_name = (
+        f"{job.name} " if job.name else ""
+    ) + f"cleanup {os.path.basename(temp_file_path)}"
+    cleanup_job = init_job(
+        batch, cleanup_job_name, job._image, cpu=0.25, memory=0.25 * 3.75
+    )
     cleanup_job.always_run()
 
-    gs_path_of_gcloud_credentials = gs_path_of_gcloud_credentials or getattr(job, "_batch_utils_gs_path_of_gcloud_credentials", None)
-    gcloud_user_account = gcloud_user_account or getattr(job, "_batch_utils_gcloud_user_account", None)
+    gs_path_of_gcloud_credentials = gs_path_of_gcloud_credentials or getattr(
+        job, "_batch_utils_gs_path_of_gcloud_credentials", None
+    )
+    gcloud_user_account = gcloud_user_account or getattr(
+        job, "_batch_utils_gcloud_user_account", None
+    )
     if not gs_path_of_gcloud_credentials:
         raise ValueError("gs_path_of_gcloud_credentials not specified")
     if not gcloud_user_account:
         raise ValueError("gcloud_user_account not specified")
-    switch_gcloud_auth_to_user_account(cleanup_job, gs_path_of_gcloud_credentials, gcloud_user_account)
+    switch_gcloud_auth_to_user_account(
+        cleanup_job, gs_path_of_gcloud_credentials, gcloud_user_account
+    )
 
     cleanup_job.command(f"gsutil -m rm -r {temp_file_path}")
     cleanup_job.depends_on(job)
 
-    return localize_file(job, temp_file_path, gcloud_project=gcloud_project, use_gcsfuse=True)
+    return localize_file(
+        job, temp_file_path, gcloud_project=gcloud_project, use_gcsfuse=True
+    )
 
 
 def generate_path_to_file_size_dict(glob):
@@ -358,14 +469,19 @@ def generate_path_to_file_size_dict(glob):
             f"gsutil -m ls -l {glob}",
             shell=True,
             stderr=subprocess.STDOUT,
-            encoding="UTF-8")
+            encoding="UTF-8",
+        )
     except subprocess.CalledProcessError as e:
         if "One or more URLs matched no objects." in e.output:
             return {}
         else:
             raise e
 
-    records = [r.strip().split("  ") for r in gsutil_output.strip().split("\n") if not r.startswith("TOTAL: ")]
+    records = [
+        r.strip().split("  ")
+        for r in gsutil_output.strip().split("\n")
+        if not r.startswith("TOTAL: ")
+    ]
     return {r[2]: int(r[0]) for r in records}  # map path to size in bytes
 
 
@@ -381,7 +497,9 @@ def batch_iter(iterable, batch_size=1):
     """
 
     if batch_size < 1:
-        raise ValueError(f"batch_size={{batch_size}}. It needs to be a positive integer.")
+        raise ValueError(
+            f"batch_size={{batch_size}}. It needs to be a positive integer."
+        )
 
     it = iter(iterable)
     while True:
@@ -414,7 +532,28 @@ def print_memory_stats(message="", run_gc=False):
     memory_bytes = psutil.Process(os.getpid()).memory_info().rss
 
     logging.info(
-        f"memory used {message}: {memory_bytes//10**6} Mb    delta: {(memory_bytes - _PREV_MEMORY_BYTES)//10**6} Mb")
+        f"memory used {message}: {memory_bytes//10**6} Mb    delta: {(memory_bytes - _PREV_MEMORY_BYTES)//10**6} Mb"
+    )
 
     _PREV_MEMORY_BYTES = memory_bytes
 
+
+def get_batch_job_names(
+    project: str, batch_id: int, status_str: str = "bad"
+) -> List[str]:
+    """
+    Filter on job status and get a list of batch job names.
+
+    :param project: Batch billing project.
+    :param batch_id: Batch job ID.
+    :param status_str: Job status. 
+        Must match options in batch UI ("ready", "running", "live", "cancelled", "error", "Failed", "bad", "success", "done").
+        Default is 'bad' (will pull 'error' and 'failed' jobs).
+    :return: List of job names.
+    """
+    client = bc.BatchClient(project)
+    b = client.get_batch(batch_id)
+    names = []
+    for job in b.jobs(q=status_str):
+        names.append(job["name"])
+    return names


### PR DESCRIPTION
Added util (code from Jackie) to get batch job names.  Used this util in UKBB and thought it might be handy for other users.

I also ran BLACK and didn't realize this script hadn't been reformatted, which is why this PR looks so large -- only lines 541-559 are new code. The rest of the new changes are BLACK edits and a small reordering of imports (these were flagged by pylint).