### PR TITLE
Updated hail version in Dockerfile

### DIFF
--- a/tgg/vm-docker/Dockerfile
+++ b/tgg/vm-docker/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get update \
 RUN python3 -m pip install --upgrade pip
 
 # Install hail and other python libraries
-ENV HAIL_VERSION="0.2.88"
+ENV HAIL_VERSION="0.2.93"
 RUN python3 --version
 RUN python3 -m pip install \
     wheel \


### PR DESCRIPTION
This PR updates the hail version in the TGG VM dockerfile to 0.2.93 -- this is the version required to run query in batch (or query on batch, which is query in batch inside a batch job; see https://hail.zulipchat.com/#narrow/stream/123011-Hail-Query-Dev/topic/query.20on.20batch.2C.20in.20batch/near/278320801).

Note that hail version 0.2.94 will likely be released soon