### PR TITLE
Update filters filter

### DIFF
--- a/tgg/seqr_scripts/sex_check.py
+++ b/tgg/seqr_scripts/sex_check.py
@@ -2,9 +2,6 @@ import argparse
 import logging
 from typing import List
 import matplotlib.pyplot as plt
-import warnings
-import sys
-
 
 import hail as hl
 
@@ -194,7 +191,7 @@ def call_sex(
 
     # Filter to pass variants only (empty set)
     # TODO: Make this an optional argument before moving to gnomad_methods
-    mt = mt.filter_rows(mt.filters.length() == 0, keep=True)
+    mt = mt.filter_rows(~hl.is_defined(mt.filters), keep=True) # NOTE: As of v0.2.102, hail imports empty sets as missing/NaN
 
     # Infer build:
     build = get_reference_genome(mt.locus).name

--- a/tgg/seqr_scripts/sex_check.py
+++ b/tgg/seqr_scripts/sex_check.py
@@ -2,6 +2,8 @@ import argparse
 import logging
 from typing import List
 import matplotlib.pyplot as plt
+import warnings
+import sys
 
 
 import hail as hl
@@ -275,7 +277,13 @@ def main(args):
 
     :param args: User's command line inputs
     """
-    call_sex(**vars(args))
+    with warnings.catch_warnings():
+        warnings.filterwarnings('RuntimeWarning', r'All-NaN (slice|axis) encountered')
+    try:
+         call_sex(**vars(args))
+    except ValueError as e:
+        logger.info("same nan error")
+        sys.exit(0)
 
 
 if __name__ == "__main__":
@@ -287,7 +295,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "-t",
-        "--temp",
+        "--temp-path",
         required=True,
         help="Path to bucket (where to store temporary data)",
     )

--- a/tgg/seqr_scripts/sex_check.py
+++ b/tgg/seqr_scripts/sex_check.py
@@ -277,7 +277,6 @@ def main(args):
     call_sex(**vars(args))
 
 
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="This script infers the sex of samples"

--- a/tgg/seqr_scripts/sex_check.py
+++ b/tgg/seqr_scripts/sex_check.py
@@ -189,7 +189,8 @@ def call_sex(
         (hl.len(mt.alleles) == 2) & hl.is_snp(mt.alleles[0], mt.alleles[1])
     )
 
-    # Filter to pass variants only (empty set)
+    # Filter to PASS variants only (variants with empty filter set)
+    # NOTE: As of v0.2.102, hail imports empty sets as missing/NaN
     # TODO: Make this an optional argument before moving to gnomad_methods
     mt = mt.filter_rows(hl.is_missing(mt.filters))
 

--- a/tgg/seqr_scripts/sex_check.py
+++ b/tgg/seqr_scripts/sex_check.py
@@ -274,13 +274,8 @@ def main(args):
 
     :param args: User's command line inputs
     """
-    with warnings.catch_warnings():
-        warnings.filterwarnings('RuntimeWarning', r'All-NaN (slice|axis) encountered')
-    try:
-         call_sex(**vars(args))
-    except ValueError as e:
-        logger.info("same nan error")
-        sys.exit(0)
+    call_sex(**vars(args))
+
 
 
 if __name__ == "__main__":

--- a/tgg/seqr_scripts/sex_check.py
+++ b/tgg/seqr_scripts/sex_check.py
@@ -191,7 +191,7 @@ def call_sex(
 
     # Filter to pass variants only (empty set)
     # TODO: Make this an optional argument before moving to gnomad_methods
-    mt = mt.filter_rows(~hl.is_defined(mt.filters), keep=True) # NOTE: As of v0.2.102, hail imports empty sets as missing/NaN
+    mt = mt.filter_rows(hl.is_missing(mt.filters))
 
     # Infer build:
     build = get_reference_genome(mt.locus).name


### PR DESCRIPTION
Hail 0.2.102 imports empty sets as missing. This change prevents all rows from being filtered by the filters filter and also updates a arg parse bug.