### PR TITLE
Mw/sex check fix

### DIFF
--- a/tgg/seqr_scripts/sex_check.py
+++ b/tgg/seqr_scripts/sex_check.py
@@ -189,7 +189,7 @@ def call_sex(
         (hl.len(mt.alleles) == 2) & hl.is_snp(mt.alleles[0], mt.alleles[1])
     )
 
-    # Filter to PASS variants only (variants with empty filter set)
+    # Filter to PASS variants only (variants with empty or missing filter set)
     # TODO: Make this an optional argument before moving to gnomad_methods
     mt = mt.filter_rows(hl.is_missing(mt.filters) | (mt.filters.length() == 0), keep=True)
 

--- a/tgg/seqr_scripts/sex_check.py
+++ b/tgg/seqr_scripts/sex_check.py
@@ -190,7 +190,6 @@ def call_sex(
     )
 
     # Filter to PASS variants only (variants with empty filter set)
-    # NOTE: As of v0.2.102, hail imports empty sets as missing/NaN so need to confirm the field is defined
     # TODO: Make this an optional argument before moving to gnomad_methods
     mt = mt.filter_rows(hl.is_missing(mt.filters) | (mt.filters.length() == 0), keep=True)
 

--- a/tgg/seqr_scripts/sex_check.py
+++ b/tgg/seqr_scripts/sex_check.py
@@ -190,9 +190,9 @@ def call_sex(
     )
 
     # Filter to PASS variants only (variants with empty filter set)
-    # NOTE: As of v0.2.102, hail imports empty sets as missing/NaN
+    # NOTE: As of v0.2.102, hail imports empty sets as missing/NaN so need to confirm the field is defined
     # TODO: Make this an optional argument before moving to gnomad_methods
-    mt = mt.filter_rows(hl.is_missing(mt.filters))
+    mt = mt.filter_rows(hl.is_missing(mt.filters) | (mt.filters.length() == 0), keep=True)
 
     # Infer build:
     build = get_reference_genome(mt.locus).name


### PR DESCRIPTION
This commit makes the function more robust by accounting for when the all the filter sets are defined and the length is zero which is what the code used prior to the last commit. It should not have been removed.